### PR TITLE
index.d.tsの追加

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+// "userSymbol": "BetterLog",
+// "libraryId": "1DSyxam1ceq72bMHsE6aOVeOl94X78WCwiYPytKi7chlg4x5GqiNXSw0l",
+// "version": "27"
+/// <reference path="@types/BetterLog.d.ts"/>
+
+//"userSymbol": "Moment",
+//"libraryId": "15hgNOjKHUG4UtyZl9clqBbl23sDvWMS8pfDJOyIapZk5RBqwL3i-rlCo",
+//"version": "9"
+/// <reference path="@types/moment_global.d.ts"/>
+
+//"userSymbol": "OAuth2",
+//"libraryId": "1B7FSrk5Zi6L1rSxxTDgDEUsPzlukDsi4KGuTMorsTQHhGBzBkMun4iDF",
+//"version": "33"
+/// <reference path="@types/OAuth2.d.ts"/>
+
+//"userSymbol": "Underscore",
+//"libraryId": "1PcEHcGVC1njZd8SfXtmgQk19djwVd2GrrW1gd7U5hNk033tzi6IUvIAV",
+//"version": "2"
+/// <reference path="@types/underscore_global.d.ts"/>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "GAS-Clasp ライブラリ自動補完",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
# What

claspでTypeScriptをトランスパイルするのではなく、TypeScriptをWebpackでトランスパイルした後にclaspでアップロードする様な使い方をしています。

`package.json` の `devDependencies`  に 追加しても、 エディタやtscに認識されなかったので、認識される様に修正してみました。

以下の様に`tsconfig.json`に設定を追加すると型情報を補完してくれる様になりました。
```tsconfig.json
{
    "compilerOptions": {
      ...
      "types": ["@types/google-apps-script", "gas_types"],
      ...
    },
    ...
  }
  ```