### PR TITLE
OAuth2のsetScopeの引数の型の修正

### DIFF
--- a/@types/OAuth2.d.ts
+++ b/@types/OAuth2.d.ts
@@ -44,8 +44,7 @@ declare class OAuth2 {
   //any -> 本来はLockService.Lock だが書き方がわからない。GoogleAppsScript.Lock.Lock?
   public setLock(lock: any): OAuth2
 
-  // 引数の型が合っているか不明
-  public setScope(scope: string[], optSeparator: string): OAuth2
+  public setScope(scope: string|string[], optSeparator?: string): OAuth2
 
   public setParam(name: string, value: string): OAuth2
   public setPrivateKey(privateKey: string): OAuth2


### PR DESCRIPTION
# What

setScopeの型を実装を参考に修正しました。

# Ref
- 実装側のコード
   https://github.com/googleworkspace/apps-script-oauth2/blob/27c61fcc15af19f9d6505d2a6170ff883f0bd868/src/Service.js#L219